### PR TITLE
Unable to deactivate the gzip compression

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -96,7 +96,7 @@
         contentDisposition = 'attachment; filename="' + filename + '"';
         res.setHeader('Content-Disposition', contentDisposition);
       }
-      if (cacheHash.gzippedData && ((_ref2 = req.headers['accept-encoding']) != null ? _ref2.indexOf(/gzip/) : void 0)) {
+      if (cacheHash.gzippedData && ((_ref2 = req.headers['accept-encoding']) != null ? _ref2.match(/gzip/) : void 0)) {
         res.setHeader('Content-Encoding', 'gzip');
         res.setHeader('Content-Length', cacheHash.gzippedData.length);
         return res.end(cacheHash.gzippedData);

--- a/src/cache.coffee
+++ b/src/cache.coffee
@@ -61,7 +61,7 @@ class ConnectFileCache
       contentDisposition = 'attachment; filename="' + filename + '"'
       res.setHeader 'Content-Disposition', contentDisposition
 
-    if cacheHash.gzippedData and req.headers['accept-encoding']?.indexOf /gzip/
+    if cacheHash.gzippedData and req.headers['accept-encoding']?.match /gzip/
       res.setHeader 'Content-Encoding', 'gzip'
       res.setHeader 'Content-Length', cacheHash.gzippedData.length
       res.end cacheHash.gzippedData


### PR DESCRIPTION
Match works better with a regular expression than indexOf.
At the moment we are unable to deactivate gzip-compression
with headers.
